### PR TITLE
Update Collection2PresetWindows.py

### DIFF
--- a/Collection2PresetWindows.py
+++ b/Collection2PresetWindows.py
@@ -133,7 +133,7 @@ if steam_path is not None:
         libraryfolders_content = file.read()
 
     # Find the Steam directory for Garry's Mod (app ID: 4000)
-    match = re.search(r"\"1\"\s+?\{\s+?\"path\"\s+?\"([^\"]+)\"", libraryfolders_content)
+    match = re.search(r"\"0\"\s+?\{\s+?\"path\"\s+?\"([^\"]+)\"", libraryfolders_content)
     if match:
         steam_directory = match.group(1)
         gmod_path = os.path.join(steam_directory, "steamapps", "common", "GarrysMod", "garrysmod", "settings")


### PR DESCRIPTION
it won't work if you don't have more than one library folder, and most people are probably only going to have one library

not sure why it doesn't work with this collection, either:
```json
{'response': {'result': 1, 'resultcount': 1, 'publishedfiledetails': [{'publishedfileid': '2817018821', 'result': 9}]}}
```

edit: turns out even though "Unlisted" workshop collections are functional for users, on the API side of things they are invisible (?)